### PR TITLE
Digit span test modes

### DIFF
--- a/src/page/adapter/digit-span-test.js
+++ b/src/page/adapter/digit-span-test.js
@@ -9,7 +9,8 @@
 		progress = $('#primary-progress-bar'),
 		speedInput = $('#speed-millis'),
 		startingLengthInput = $('#starting-length'),
-		audioEnabledCheckbox = $('#audio-enabled');
+		audioEnabledCheckbox = $('#audio-enabled'),
+		testModeSelect = $('#test-mode');
 
 	// digit test object
 	var test = null;
@@ -17,6 +18,7 @@
 	var speed = 1000; // milliseconds between symbols
 	var defaultStartingLength = 4, lastLength = 0;
 	var audioEnabled = true, visualEnabled = true;
+	var testMode = DigitSpanTest.modes.DEFAULT;
 
 	var state = "loaded"; // possible states: ["loaded", "started", "success"]
 
@@ -107,7 +109,8 @@
 	}
 
 	function checkUserInput(input) {
-		if (input == test.getSequence()[symbolIndex]) {
+		const targetChar = test.getTargetSequence(testMode)[symbolIndex];
+		if (input == targetChar) {
 			symbolIndex++;
 
 			// update progress bar
@@ -147,6 +150,19 @@
 		if (test === null) return;
 		checkUserInput(event.key);
 		clearInput();
+	});
+
+	testModeSelect.on('change', function() {
+		var newModeInput = testModeSelect.val();
+		var val2mode = {
+			'default': DigitSpanTest.modes.DEFAULT,
+			'reversed': DigitSpanTest.modes.REVERSED,
+			'ordered': DigitSpanTest.modes.ORDERED
+		};
+		if (!newModeInput in val2mode) {
+			throw new Error(`Invalid test mode selected '${newModeInput}`);
+		}
+		testMode = val2mode[newModeInput];
 	});
 
 

--- a/src/page/adapter/digit-span-test.js
+++ b/src/page/adapter/digit-span-test.js
@@ -97,7 +97,8 @@
 	}
 
 	function failed() {
-		infoDiv.html("You have failed at a digit sequence length of " + test.getSequence().length + ". The correct sequence was " + test.getSequence().join(''));
+		infoDiv.html(`You have failed at a digit sequence length of ${test.getSequence().length}. ` +
+			`The shown sequence was "${test.getSequence()}" and you should have entered "${test.getTargetSequence(testMode)}".`);
 		setDisabled(userInput, true);
 		setDisabled(primaryButton, false);
 		setDisabled(repeatButton, false);
@@ -163,7 +164,7 @@
 			throw new Error(`Invalid test mode selected '${newModeInput}`);
 		}
 		testMode = val2mode[newModeInput];
-	});
+	}).trigger('change');
 
 
 	// settings

--- a/src/page/content/digit-span-test.php
+++ b/src/page/content/digit-span-test.php
@@ -49,5 +49,13 @@
 				<div class="input-group-addon">symbols</div>
 			</div>
 		</div>
+		<div class="form-group">
+			<label for="test-mode">Test mode</label>
+			<select name="test-mode" id="test-mode" class="form-control">
+				<option value="default" selected>Forward (default)</option>
+				<option value="reversed">Reversed</option>
+				<option value="ordered">Ordered</option>
+			</select>
+		</div>
 	</div>
 </div>

--- a/src/page/content/digit-span-test.php
+++ b/src/page/content/digit-span-test.php
@@ -28,8 +28,28 @@
 		<button id="primary-btn" type="button" class="btn btn-primary btn-lg" disabled="disabled">Start</button>
 		<button id="repeat-btn" type="button" class="btn btn-default btn-lg" disabled="disabled">Repeat</button>
 	</div>
-	<div class="col-xs-12 col-sm-6 col-md-4">
+	<div class="col-xs-12">
 		<h4>Settings</h4>
+	</div>
+	<div class="col-xs-12 col-sm-6 col-md-6">
+		<div class="form-group">
+			<label for="test-mode">Test mode</label>
+			<select name="test-mode" id="test-mode" class="form-control">
+				<option value="default" selected>Forward (default)</option>
+				<option value="reversed">Reversed</option>
+				<option value="ordered">Ordered</option>
+			</select>
+			<div class="bg-info padding-15px" id="info-output">
+				Depending on the selected mode, the target order, i.e. the order in which the symbols must be entered, changes:
+				<ul>
+					<li><b>Forward (default)</b> requires the symbols to be entered in the order in which they were shown.</li>
+					<li><b>Reversed</b> is the opposite of forward, e.g. "1532" should be entered as "2351".</li>
+					<li><b>Ordered</b> is the numbers in ascending order, e.g. "1532" becomes "1235".</li>
+				</ul>
+			</div>
+		</div>
+	</div>
+	<div class="col-xs-12 col-sm-6 col-md-4">
 		<div class="checkbox">
 			<label>
 				<input id="audio-enabled" type="checkbox" checked="checked"> Sound enabled
@@ -48,14 +68,6 @@
 				<input id="starting-length" type="number" min="1" step="1" class="form-control" placeholder="4" value="4">
 				<div class="input-group-addon">symbols</div>
 			</div>
-		</div>
-		<div class="form-group">
-			<label for="test-mode">Test mode</label>
-			<select name="test-mode" id="test-mode" class="form-control">
-				<option value="default" selected>Forward (default)</option>
-				<option value="reversed">Reversed</option>
-				<option value="ordered">Ordered</option>
-			</select>
 		</div>
 	</div>
 </div>

--- a/src/page/logic/digit-span-test.js
+++ b/src/page/logic/digit-span-test.js
@@ -16,7 +16,20 @@ function DigitSpanTest(options) {
 }
 
 DigitSpanTest.prototype.getSequence = function() {
-	return this.sequence;
+	return [...this.sequence];
+};
+
+DigitSpanTest.prototype.getTargetSequence = function(mode) {
+    switch (mode) {
+        case DigitSpanTest.modes.DEFAULT:
+            return this.getSequence();
+        case DigitSpanTest.modes.REVERSED:
+            return this.getSequence().reverse();
+        case DigitSpanTest.modes.ORDERED:
+            return this.getSequence().sort();
+        default:
+            throw new Error(`Invalid mode '${mode}'.`);
+    }
 };
 
 DigitSpanTest.prototype.next = function() {
@@ -32,7 +45,13 @@ DigitSpanTest.prototype.generateSequence = function() {
 		sequence.push(this.symbols[index])
 	}
 	return sequence;
-}
+};
+
+DigitSpanTest.modes = {
+    DEFAULT: 0,
+    REVERSED: 1,
+    ORDERED: 2
+};
 
 
 // sound class from https://stackoverflow.com/questions/11330917/how-to-play-a-mp3-using-javascript
@@ -46,7 +65,7 @@ function Sound(source, volume, loop) {
 
     this.stop = function() {
         document.body.removeChild(this.son);
-    }
+    };
 
     this.start = function() {
         if (this.finish) return false;
@@ -57,16 +76,16 @@ function Sound(source, volume, loop) {
         this.son.setAttribute("autostart", "true");
         this.son.setAttribute("loop", this.loop);
         document.body.appendChild(this.son);
-    }
+    };
 
     this.remove = function() {
         document.body.removeChild(this.son);
         this.finish = true;
-    }
+    };
 
     this.init = function(volume, loop) {
         this.finish = false;
         this.volume = volume;
         this.loop = loop;
-    }
+    };
 }

--- a/src/page/meta-data/digit-span-test.txt
+++ b/src/page/meta-data/digit-span-test.txt
@@ -1,5 +1,5 @@
 Digit span test
-Test how man digits you can remember in your short-term memory.
+Test how many digits you can remember in your short-term memory.
 digit span test;memory;psychology
 A digit-span task is used to measure working memory's number storage capacity. Participants see or hear a sequence of numerical digits and are tasked to recall the sequence correctly, with increasingly longer sequences being tested in each trial.
 https://en.wikipedia.org/wiki/Memory_span#Digit-span


### PR DESCRIPTION
As requested in #11 this PR adds functionality for backward and reversed digit span testing. Merging resolves #11.

![image](https://user-images.githubusercontent.com/6556307/71291400-d4b38480-2372-11ea-87e5-b03c2e9ba775.png)  
_Fig.: Screenshot from the tool._
