### PR TITLE
Omitting of very small coefficients in interpolation tool

### DIFF
--- a/src/page/adapter/cubic-spline-interpolation.js
+++ b/src/page/adapter/cubic-spline-interpolation.js
@@ -164,8 +164,15 @@
 		for (var i = 0; i < functions.length; i++) {
 			var f = functions[i];
 			// approximate output
-			html += roundMathJax(f.a) + '\\cdot x^3 + ' + roundMathJax(f.b) + '\\cdot x^2 + ' + roundMathJax(f.c) + '\\cdot x + ' + roundMathJax(f.d) + ', & \\text{if } x \\in ' + ((i == 0) ? "[" : "(") + f.range.xmin + ',' + f.range.xmax + ']' + ((i !== functions.length - 1) ? ', \\\\' : '.\\end{cases}$$');
+			html += roundMathJax(f.a) + '\\cdot x^3 + ' + 
+					roundMathJax(f.b) + '\\cdot x^2 + ' + 
+					roundMathJax(f.c) + '\\cdot x + ' + 
+					roundMathJax(f.d) + 
+					', & \\text{if } x \\in ' + 
+					((i === 0) ? "[" : "(") + f.range.xmin + ',' + f.range.xmax + ']' + 
+					((i !== functions.length - 1) ? ', \\\\' : '.\\end{cases}$$');
 		}
+		html = html.replace(/\+ \-/g, "-");
 		divEquationOutput.html(html);
 
 		// draw equation

--- a/src/page/adapter/polynomial-interpolation.js
+++ b/src/page/adapter/polynomial-interpolation.js
@@ -160,14 +160,18 @@
 		var html = '$$f(x)=';
  		for (var i = 0; i < coefficients.length; i++) {
  			var c = coefficients[i];
- 			if (i !== 0) html += '+';
- 			html += roundMathJax(c);
+			if (Math.abs(c) > 1e-30) {
+				if (i !== 0) html += '+ ';
+				html += roundMathJax(c);
 
- 			// different styling for last to segments
- 			if (i == coefficients.length - 2) html += '\\cdot x';
- 			if (i < coefficients.length - 2) html += '\\cdot x^{' + (coefficients.length - i - 1) + '}';
+				// different styling for last to segments
+				if (i == coefficients.length - 2) html += '\\cdot x';
+				if (i < coefficients.length - 2) html += '\\cdot x^{' + (coefficients.length - i - 1) + '}';
+			}
  		}
 		html += '$$';
+		html = html.replace(/\+ \-/g, "-");
+		html = html.replace(/\=\+/g, "=");
 		divEquationOutput.html(html);
 
 		// draw equation

--- a/src/page/adapter/polynomial-interpolation.js
+++ b/src/page/adapter/polynomial-interpolation.js
@@ -158,18 +158,24 @@
 		// draw equation
 		MathJax.Hub.Queue(["Typeset", MathJax.Hub, document.getElementById('equation-output')]);
 		var html = '$$f(x)=';
+		var eqRightHand = '';
  		for (var i = 0; i < coefficients.length; i++) {
  			var c = coefficients[i];
 			if (Math.abs(c) > 1e-30) {
-				if (i !== 0) html += '+ ';
-				html += roundMathJax(c);
+				if (i !== 0) {
+					eqRightHand += '+ ';
+				}
+				eqRightHand += roundMathJax(c);
 
 				// different styling for last to segments
-				if (i == coefficients.length - 2) html += '\\cdot x';
-				if (i < coefficients.length - 2) html += '\\cdot x^{' + (coefficients.length - i - 1) + '}';
+				if (i == coefficients.length - 2) eqRightHand += '\\cdot x';
+				if (i < coefficients.length - 2) eqRightHand += '\\cdot x^{' + (coefficients.length - i - 1) + '}';
 			}
- 		}
-		html += '$$';
+		 }
+		if (eqRightHand.length === 0) {
+			eqRightHand = '0';
+		}
+		html += eqRightHand + '$$';
 		html = html.replace(/\+ \-/g, "-");
 		html = html.replace(/\=\+/g, "=");
 		divEquationOutput.html(html);


### PR DESCRIPTION
Fixes #14, which was about very small coefficients being shown (e.g. 10^-50) which is unreasonable. The fix checks whether the absolute value of a number is greater than a predefined threshold and only shows the coefficient if that is the case.